### PR TITLE
fix topology level option for SOL benchmark

### DIFF
--- a/benchmark/SOL/run.sh
+++ b/benchmark/SOL/run.sh
@@ -32,7 +32,7 @@ MESSAGE_SIZE=100
 SPOUT_NUM=4
 BOLT_NUM=4
 
-TOPOLOGY_CONF=topology.name=$TOPOLOGY_NAME,topology.workers=$WORKERS,topology.acker.executors=$ACKERS,topology.max.spout.pending=$PENDING,topology.level=$TOPOLOGY_LEVEL,component.spout_num=$SPOUT_NUM,component.bolt_num=$BOLT_NUM
+TOPOLOGY_CONF=topology.name=$TOPOLOGY_NAME,topology.workers=$WORKERS,topology.acker.executors=$ACKERS,topology.max.spout.pending=$PENDING,benchmarks.level=$TOPOLOGY_LEVEL,component.spout_num=$SPOUT_NUM,component.bolt_num=$BOLT_NUM
 
 echo "========== running SOL =========="
 run_benchmark


### PR DESCRIPTION
The SOL benchmark supports a configurable number of chained bolts. This fixes the config option so the configuration will actually take effect.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/manuzhang/storm-benchmark/3)

<!-- Reviewable:end -->
